### PR TITLE
Fix intervention token device placement

### DIFF
--- a/SAE/compare_representations.py
+++ b/SAE/compare_representations.py
@@ -275,8 +275,8 @@ def analyze_intervention(model, dataset1_path, dataset2_path, neuron_analysis_re
                 tokens1 = model.to_tokens(text1)
                 tokens2 = model.to_tokens(text2)
 
-                tokens1 = tokens1.to(model.embed.W_E.device)
-                tokens2 = tokens2.to(model.embed.W_E.device)
+                tokens1 = tokens1.to(model.cfg.device)
+                tokens2 = tokens2.to(model.cfg.device)
 
                 # 1. Clean runs
                 _, cache1_clean = model.run_with_cache(tokens1)


### PR DESCRIPTION
## Summary
- ensure intervention analysis tokens move to the model's primary shard device instead of the embedding weight device

## Testing
- `python SAE/compare_representations.py --mode intervention --model_name google/gemma-2-2b --dataset1_path dummy --dataset2_path dummy --module mlp` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_b_68cbb98d1a948333af1501680be3e9ea